### PR TITLE
Add generic github issue templates to the backstage-operator repository

### DIFF
--- a/.github/ISSUE_TEMPLATE/blank.md
+++ b/.github/ISSUE_TEMPLATE/blank.md
@@ -1,0 +1,5 @@
+---
+name: Blank Template
+about: Create a blank issue
+labels: [status/triage]
+---

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,19 @@
+---
+name: Bug Report
+about: If something isn't working
+labels: ["kind/bug", "status/triage"]
+---
+
+### Describe the bug
+
+A clear and concise description of what the bug is. (provide screenshots if applicable)
+
+### Expected Behavior
+
+### What are the steps to reproduce this bug?
+
+1. …
+2. …
+3. …
+
+### Versions of software used and environment

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,7 +1,7 @@
 ---
 name: Bug Report
 about: If something isn't working
-labels: ["kind/bug", "status/triage"]
+labels: [kind/bug, status/triage]
 ---
 
 ### Describe the bug

--- a/.github/ISSUE_TEMPLATE/chore.md
+++ b/.github/ISSUE_TEMPLATE/chore.md
@@ -1,0 +1,7 @@
+---
+name: Chore
+about: Internal things, technical debt, and to-do tasks to be performed.
+labels: ['kind/chore', 'status/triage']
+---
+
+### What needs to be done?

--- a/.github/ISSUE_TEMPLATE/chore.md
+++ b/.github/ISSUE_TEMPLATE/chore.md
@@ -1,7 +1,7 @@
 ---
 name: Chore
 about: Internal things, technical debt, and to-do tasks to be performed.
-labels: ['kind/chore', 'status/triage']
+labels: ["kind/chore", "status/triage"]
 ---
 
 ### What needs to be done?

--- a/.github/ISSUE_TEMPLATE/chore.md
+++ b/.github/ISSUE_TEMPLATE/chore.md
@@ -1,7 +1,7 @@
 ---
 name: Chore
 about: Internal things, technical debt, and to-do tasks to be performed.
-labels: ["kind/chore", "status/triage"]
+labels: [kind/chore, status/triage]
 ---
 
 ### What needs to be done?

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: ❓ Janus IDP Community Slack
+    url: https://join.slack.com/t/janus-idp/shared_invite/zt-1pxtehxom-fCFtF9rRe3vFqUiFFeAkmg
+    about: Please ask and answer questions here.

--- a/.github/ISSUE_TEMPLATE/documentation.md
+++ b/.github/ISSUE_TEMPLATE/documentation.md
@@ -1,0 +1,11 @@
+---
+name: Documentation
+about: Improve an existing feature or workflow
+labels: ['kind/documentation', 'status/triage']
+---
+
+### What do you want to improve?
+
+### What is the current documentation?
+
+### What is the new documentation?

--- a/.github/ISSUE_TEMPLATE/documentation.md
+++ b/.github/ISSUE_TEMPLATE/documentation.md
@@ -1,7 +1,7 @@
 ---
 name: Documentation
 about: Improve an existing feature or workflow
-labels: ['kind/documentation', 'status/triage']
+labels: [kind/documentation, status/triage]
 ---
 
 ### What do you want to improve?

--- a/.github/ISSUE_TEMPLATE/enhancement.md
+++ b/.github/ISSUE_TEMPLATE/enhancement.md
@@ -1,0 +1,11 @@
+---
+name: Enhancement
+about: Improve an existing feature or workflow
+labels: ["kind/enhancement", "status/triage"]
+---
+
+### What do you want to improve?
+
+### What is the current behavior?
+
+### What is the new behavior?

--- a/.github/ISSUE_TEMPLATE/enhancement.md
+++ b/.github/ISSUE_TEMPLATE/enhancement.md
@@ -1,7 +1,7 @@
 ---
 name: Enhancement
 about: Improve an existing feature or workflow
-labels: ["kind/enhancement", "status/triage"]
+labels: [kind/enhancement, status/triage]
 ---
 
 ### What do you want to improve?

--- a/.github/ISSUE_TEMPLATE/epic.md
+++ b/.github/ISSUE_TEMPLATE/epic.md
@@ -1,0 +1,25 @@
+---
+name: Epic
+about: A long-lived, PM-driven feature request. Must include a checklist of items that must be completed
+labels: ["kind/epic", "status/triage"]
+---
+
+## Goal
+
+## Acceptance criteria
+
+- [ ] tdb
+
+## Requirements
+
+- [ ] Test plan
+- [ ] Documentation
+
+## Issues in Epic
+
+- [ ] tbd
+
+## Notes
+
+**Additional context**
+Add any other context or screenshots about the epic here.

--- a/.github/ISSUE_TEMPLATE/epic.md
+++ b/.github/ISSUE_TEMPLATE/epic.md
@@ -1,7 +1,7 @@
 ---
 name: Epic
 about: A long-lived, PM-driven feature request. Must include a checklist of items that must be completed
-labels: ["kind/epic", "status/triage"]
+labels: [kind/epic, status/triage]
 ---
 
 ## Goal

--- a/.github/ISSUE_TEMPLATE/quality.md
+++ b/.github/ISSUE_TEMPLATE/quality.md
@@ -1,0 +1,37 @@
+---
+name: Quality Assurance
+about: Tests for code changes
+labels: ['kind/quality', 'status/triage']
+---
+
+### What needs to be tested
+
+### Describe how to verify the feature and functionality
+
+### Prerequisites and test environment
+
+-
+-
+-
+
+### Describe configuration requirements
+
+-
+-
+-
+
+### Test Suites
+
+Outline the test suites and testing steps required:
+
+**Test case 1:**
+
+- Step 1-1
+- Step 1-2
+- Step 1-3
+
+**Test case 2:**
+
+- Step 2-1
+- Step 2-2
+- Step 2-3

--- a/.github/ISSUE_TEMPLATE/quality.md
+++ b/.github/ISSUE_TEMPLATE/quality.md
@@ -1,7 +1,7 @@
 ---
 name: Quality Assurance
 about: Tests for code changes
-labels: ['kind/quality', 'status/triage']
+labels: [kind/quality, status/triage]
 ---
 
 ### What needs to be tested


### PR DESCRIPTION
## Description
Adds generic github issue templates to the backstage-operator repository

## What issue(s) does this fix?
Fixes #6

## Special Notes to Reviewers
The issue labels will need to be updated to fit the standard labels in the organization.
Ex: `kind/documentation` instead of just `documentation`, and also labels such as `status/triage`.