### PR TITLE
set `global.clusterRouterBase` based on domain from cluster's ingress config

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 Reconciler logic: https://github.com/operator-framework/helm-operator-plugins/blob/main/pkg/reconciler/reconciler.go
 Hybrid operators lacks documentation, see:
-- https://github.com/operator-framework/helm-operator-plugins/issues/136
+
+- https://gthub.com/operator-framework/helm-operator-plugins/issues/136
 - https://docs.openshift.com/container-platform/4.10/operators/operator_sdk/helm/osdk-hybrid-helm.html
 
 ## Setup
@@ -14,7 +15,6 @@ make install
 
 ## Run
 
-
 Containerized:
 
 ```console
@@ -25,7 +25,8 @@ make deploy
 ```
 
 Or locally:
-```
+
+```console
 export WATCH_NAMESPACE=baz
 make run
 ```
@@ -38,5 +39,8 @@ Or in VSCode:
 
 ## Known issues
 
-- Before first sync we need to pull `oc get ingresses.config/cluster -o jsonpath={.spec.domain}` data and set as `.global.clusterRouterBase`
 - After first sync/install (before any upgrade call or reconcile), we need to set `.upstream.postgresql.auth.existingSecret`
+
+## Extra features on top of the Helm chart
+
+- `global.clusterRouterBase` is automaticaly populated with the cluster's ingress domain.

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/janus-idp/operator
+module github.com/janus-idp/backstage-operator
 
 go 1.19
 

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.19
 require (
 	github.com/go-logr/logr v1.2.3
 	github.com/operator-framework/helm-operator-plugins v0.0.11
+	github.com/stretchr/testify v1.8.1
 	helm.sh/helm/v3 v3.11.1
 	k8s.io/apimachinery v0.26.0
 	k8s.io/client-go v0.26.0
@@ -91,6 +92,7 @@ require (
 	github.com/operator-framework/operator-lib v0.11.0 // indirect
 	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect
 	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_golang v1.14.0 // indirect
 	github.com/prometheus/client_model v0.3.0 // indirect
 	github.com/prometheus/common v0.37.0 // indirect
@@ -103,7 +105,6 @@ require (
 	github.com/spf13/cast v1.4.1 // indirect
 	github.com/spf13/cobra v1.6.1 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
-	github.com/stretchr/objx v0.5.0 // indirect
 	github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f // indirect
 	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
 	github.com/xeipuuv/gojsonschema v1.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -556,6 +556,7 @@ github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
+github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f h1:J9EGpcZtP0E/raorCMxlFGSTBrsSlaDGf3jU/qvAE2c=
 github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=

--- a/pkg/hooks/prehook.go
+++ b/pkg/hooks/prehook.go
@@ -1,0 +1,62 @@
+package hooks
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/go-logr/logr"
+	"helm.sh/helm/v3/pkg/chartutil"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// SetClusterRouterBase hook sets the global.clusterRouterBase in Chart's values to the cluster's ingress domain
+type SetClusterRouterBase struct {
+	Client client.Client
+}
+
+func (h *SetClusterRouterBase) Exec(obj *unstructured.Unstructured, vals chartutil.Values, log logr.Logger) error {
+
+	ingressConfig := &unstructured.Unstructured{}
+	ingressConfig.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   "config.openshift.io",
+		Kind:    "Ingress",
+		Version: "v1",
+	})
+
+	err := h.Client.Get(context.Background(), client.ObjectKey{
+		Name:      "cluster",
+		Namespace: "",
+	}, ingressConfig)
+
+	if err != nil {
+		if errors.IsNotFound(err) || meta.IsNoMatchError(err) {
+			log.V(1).Info("PreHook: no cluster ingress config found, skipping setting global.clusterRouterBase")
+			return nil
+		}
+		return err
+	}
+
+	domain, found, err := unstructured.NestedString(ingressConfig.Object, "spec", "domain")
+	if err != nil {
+		return err
+	}
+	if !found {
+		log.V(1).Info("PreHook: no spec.domain in Ingress cluster config, skipping setting global.clusterRouterBase")
+		return nil
+	}
+
+	_, ok := vals.AsMap()["global"]
+	if !ok {
+		vals["global"] = map[string]interface{}{}
+	}
+
+	vals["global"].(map[string]interface{})["clusterRouterBase"] = domain
+
+	log.V(1).Info(fmt.Sprintf("PreHook: setting global.clusterRouterBase to %s", domain))
+
+	return nil
+}

--- a/pkg/hooks/prehook_test.go
+++ b/pkg/hooks/prehook_test.go
@@ -1,0 +1,128 @@
+package hooks_test
+
+import (
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/janus-idp/backstage-operator/pkg/hooks"
+	"github.com/stretchr/testify/assert"
+	"helm.sh/helm/v3/pkg/chartutil"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+// getIngressWithDomain returns an Ingress.config.openshift.io/v1 object with the given domain
+func getIngressWithDomain(domain string) *unstructured.Unstructured {
+	obj := &unstructured.Unstructured{}
+	obj.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   "config.openshift.io",
+		Kind:    "Ingress",
+		Version: "v1",
+	})
+
+	obj.SetName("cluster")
+	obj.SetNamespace("")
+
+	unstructured.SetNestedField(obj.Object, domain, "spec", "domain")
+	return obj
+}
+
+func TestSetClusterRouterBase(t *testing.T) {
+
+	type args struct {
+		obj  *unstructured.Unstructured
+		vals chartutil.Values
+		log  logr.Logger
+	}
+
+	tests := []struct {
+		name    string
+		client  client.Client
+		args    args
+		wantErr bool
+		// wantVals is the expected values after the hook has been executed
+		wantVals chartutil.Values
+	}{
+		{
+			name:   "ingress config found, empty chart values",
+			client: fake.NewClientBuilder().WithRuntimeObjects(getIngressWithDomain("example.com")).Build(),
+			args: args{
+				obj:  &unstructured.Unstructured{},
+				vals: chartutil.Values{},
+				log:  logr.Discard(),
+			},
+			wantErr: false,
+			wantVals: chartutil.Values{
+				"global": map[string]interface{}{
+					"clusterRouterBase": "example.com",
+				},
+			},
+		},
+		{
+			name:   "ingress config found, existing chart values, but no global section",
+			client: fake.NewClientBuilder().WithRuntimeObjects(getIngressWithDomain("example.com")).Build(),
+			args: args{
+				obj:  &unstructured.Unstructured{},
+				vals: chartutil.Values{"upstream": "foo"},
+				log:  logr.Discard(),
+			},
+			wantErr: false,
+			wantVals: chartutil.Values{
+				"upstream": "foo",
+				"global": map[string]interface{}{
+					"clusterRouterBase": "example.com",
+				},
+			},
+		},
+		{
+			name:   "ingress config found",
+			client: fake.NewClientBuilder().WithRuntimeObjects(getIngressWithDomain("example.com")).Build(),
+			args: args{
+				obj: &unstructured.Unstructured{},
+				vals: chartutil.Values{
+					"global": map[string]interface{}{},
+				},
+				log: logr.Discard(),
+			},
+			wantErr: false,
+			wantVals: chartutil.Values{
+				"global": map[string]interface{}{
+					"clusterRouterBase": "example.com",
+				},
+			},
+		},
+		{
+			name:   "ingress config not found",
+			client: fake.NewClientBuilder().WithRuntimeObjects().Build(),
+			args: args{
+				obj: &unstructured.Unstructured{},
+				vals: chartutil.Values{
+					"global": map[string]interface{}{},
+				},
+				log: logr.Discard(),
+			},
+			wantErr: false,
+			wantVals: chartutil.Values{
+				"global": map[string]interface{}{},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			hook := &hooks.SetClusterRouterBase{
+				Client: tt.client,
+			}
+			err := hook.Exec(tt.args.obj, tt.args.vals, tt.args.log)
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("SetClusterRouterBase.Exec() error = %v, wantErr %v", err, tt.wantErr)
+			}
+
+			assert.EqualValues(t, tt.wantVals, tt.args.vals)
+
+		})
+	}
+}


### PR DESCRIPTION
fixed #4 

There are still some problems with this:
- ~~overrides `clusterRouterBase` even if it is set by the user (maybe not a problem?)~~ (https://github.com/janus-idp/backstage-operator/pull/11#issuecomment-1713982871)
- we still can't use `{{- include "janus-idp.hostname" . }}` as  `baseUrl` values and benefit from `clusterRouterBase` due to https://github.com/janus-idp/helm-backstage/issues/97


Merge only after https://github.com/janus-idp/backstage-operator/pull/18