### PR TITLE
Add checkPostPassword PostHook

### DIFF
--- a/main.go
+++ b/main.go
@@ -26,7 +26,6 @@ import (
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 
 	"github.com/janus-idp/backstage-operator/pkg/hooks"
-
 	"github.com/operator-framework/helm-operator-plugins/pkg/annotation"
 	"github.com/operator-framework/helm-operator-plugins/pkg/reconciler"
 	"github.com/operator-framework/helm-operator-plugins/pkg/watches"
@@ -131,6 +130,10 @@ func main() {
 			Client: cl,
 		}
 
+		checkPostPassword := &hooks.CheckPostPassword{
+			Client: cl,
+		}
+
 		r, err := reconciler.New(
 			reconciler.WithChart(*w.Chart),
 			reconciler.WithGroupVersionKind(w.GroupVersionKind),
@@ -142,6 +145,7 @@ func main() {
 			reconciler.WithUpgradeAnnotations(annotation.DefaultUpgradeAnnotations...),
 			reconciler.WithUninstallAnnotations(annotation.DefaultUninstallAnnotations...),
 			reconciler.WithPreHook(setClusterRouterBaseHook),
+			reconciler.WithPostHook(checkPostPassword),
 		)
 
 		if err != nil {

--- a/pkg/hooks/posthook.go
+++ b/pkg/hooks/posthook.go
@@ -1,0 +1,104 @@
+package hooks
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/go-logr/logr"
+	"helm.sh/helm/v3/pkg/release"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type CheckPostPassword struct {
+	Client client.Client
+}
+
+// PostHook function to determine if upstream.postgresql.auth.password and upstream.postgresql.auth.postgresPassword has been set.
+// Sets those parameters to the secret that has been created after the chart has been installed
+func (h *CheckPostPassword) Exec(obj *unstructured.Unstructured, rel release.Release, log logr.Logger) error {
+	name := h.getName(rel)
+	secretConfig, err := h.getSecretConfig(rel, name, log)
+	if err != nil {
+		return err
+	}
+
+	if h.shouldSkipSettingPassword(rel) || secretConfig == nil {
+		log.V(1).Info("PostHook: skipping setting upstream.postgresql.auth.password and upstream.postgresql.auth.postgresPassword")
+		return nil
+	}
+
+	pass := secretConfig.Object["data"].(map[string]interface{})["password"]
+	postPass := secretConfig.Object["data"].(map[string]interface{})["postgres-password"]
+
+	h.setAuthPasswords(rel, pass, postPass)
+
+	log.V(1).Info(fmt.Sprintf("PostHook: setting upstream.postgresql.auth.password and upstream.postgresql.auth.postgresPassword from %s", secretConfig.GetName()))
+
+	return nil
+}
+
+func (h *CheckPostPassword) getName(rel release.Release) string {
+	fullnameOverride, fnFound, _ := unstructured.NestedString(rel.Config, "upstream", "postgresql", "fullnameOverride")
+	nameOverride, nFound, _ := unstructured.NestedString(rel.Config, "upstream", "postgresql", "nameOverride")
+
+	if fnFound && len(fullnameOverride) > 0 {
+		return fullnameOverride
+	} else if nFound && len(nameOverride) > 0 {
+		return rel.Name + "-" + nameOverride
+	}
+
+	return rel.Name + "-postgresql"
+}
+
+func (h *CheckPostPassword) getSecretConfig(rel release.Release, name string, log logr.Logger) (*unstructured.Unstructured, error) {
+	secretConfig := &unstructured.Unstructured{}
+	secretConfig.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   "",
+		Kind:    "Secret",
+		Version: "v1",
+	})
+
+	err := h.Client.Get(context.Background(), client.ObjectKey{
+		Name:      name,
+		Namespace: rel.Namespace,
+	}, secretConfig)
+
+	if err != nil {
+		if errors.IsNotFound(err) || meta.IsNoMatchError(err) {
+			log.V(1).Info("PostHook: no postgres secret found, skipping setting upstream.postgresql.auth.password and upstream.postgresql.auth.postgresPassword")
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	return secretConfig, nil
+}
+
+func (h *CheckPostPassword) shouldSkipSettingPassword(rel release.Release) bool {
+	_, passFound, _ := unstructured.NestedString(rel.Config, "upstream", "postgresql", "auth", "password")
+	_, postFound, _ := unstructured.NestedString(rel.Config, "upstream", "postgresql", "auth", "postgresPassword")
+
+	return passFound && postFound
+}
+
+func (h *CheckPostPassword) setAuthPasswords(rel release.Release, pass interface{}, postPass interface{}) {
+	ensureNestedMap(rel.Chart.Values, "upstream", "postgresql", "auth")
+
+	rel.Chart.Values["upstream"].(map[string]interface{})["postgresql"].(map[string]interface{})["auth"].(map[string]interface{})["password"] = pass
+	rel.Chart.Values["upstream"].(map[string]interface{})["postgresql"].(map[string]interface{})["auth"].(map[string]interface{})["postgresPassword"] = postPass
+}
+
+// Helper function to ensure that the nested map, upstream.posgresql.auth, is there
+func ensureNestedMap(m map[string]interface{}, keys ...string) {
+	for _, key := range keys {
+		_, ok := m[key].(map[string]interface{})
+		if !ok {
+			m[key] = map[string]interface{}{}
+		}
+		m = m[key].(map[string]interface{})
+	}
+}

--- a/pkg/hooks/posthook_test.go
+++ b/pkg/hooks/posthook_test.go
@@ -1,0 +1,277 @@
+package hooks_test
+
+import (
+	"encoding/base64"
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/janus-idp/backstage-operator/pkg/hooks"
+	"github.com/stretchr/testify/assert"
+	"helm.sh/helm/v3/pkg/chart"
+	"helm.sh/helm/v3/pkg/release"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func getSecretWithData(password string, postPassword string) *unstructured.Unstructured {
+	obj := &unstructured.Unstructured{}
+	obj.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   "",
+		Kind:    "Secret",
+		Version: "v1",
+	})
+
+	obj.SetName("test-postgresql")
+	obj.SetNamespace("test")
+
+	passEncoded := base64.StdEncoding.EncodeToString([]byte(password))
+	postEncoded := base64.StdEncoding.EncodeToString([]byte(postPassword))
+
+	unstructured.SetNestedField(obj.Object, passEncoded, "data", "password")
+	unstructured.SetNestedField(obj.Object, postEncoded, "data", "postgres-password")
+	return obj
+}
+
+func TestCheckPostPassword(t *testing.T) {
+	type args struct {
+		obj *unstructured.Unstructured
+		rel release.Release
+		log logr.Logger
+	}
+
+	tests := []struct {
+		name    string
+		client  client.Client
+		args    args
+		wantErr bool
+		// wantVals is the expected values after the hook has been executed
+		wantVals map[string]interface{}
+	}{
+		{
+			name:   "secret config found, empty chart values",
+			client: fake.NewClientBuilder().WithRuntimeObjects(getSecretWithData("pass123", "post123")).Build(),
+			args: args{
+				obj: &unstructured.Unstructured{},
+				rel: release.Release{
+					Name:      "test",
+					Namespace: "test",
+					Chart: &chart.Chart{
+						Values: map[string]interface{}{},
+					},
+				},
+				log: logr.Discard(),
+			},
+			wantErr: false,
+			wantVals: map[string]interface{}{
+				"upstream": map[string]interface{}{
+					"postgresql": map[string]interface{}{
+						"auth": map[string]interface{}{
+							"password":         "cGFzczEyMw==", // notsecret test secret
+							"postgresPassword": "cG9zdDEyMw==", // notsecret test secret
+						},
+					},
+				},
+			},
+		},
+		{
+			name:   "secret config found, existing chart values, but no upstream.postgresql.auth section",
+			client: fake.NewClientBuilder().WithRuntimeObjects(getSecretWithData("pass123", "post123")).Build(),
+			args: args{
+				obj: &unstructured.Unstructured{},
+				rel: release.Release{
+					Name:      "test",
+					Namespace: "test",
+					Chart: &chart.Chart{
+						Values: map[string]interface{}{
+							"upstream": map[string]interface{}{
+								"foo": "baz",
+							},
+						},
+					},
+				},
+				log: logr.Discard(),
+			},
+			wantErr: false,
+			wantVals: map[string]interface{}{
+				"upstream": map[string]interface{}{
+					"foo": "baz",
+					"postgresql": map[string]interface{}{
+						"auth": map[string]interface{}{
+							"password":         "cGFzczEyMw==", // notsecret test secret
+							"postgresPassword": "cG9zdDEyMw==", // notsecret test secret
+						},
+					},
+				},
+			},
+		},
+		{
+			name:   "secret config found",
+			client: fake.NewClientBuilder().WithRuntimeObjects(getSecretWithData("pass123", "post123")).Build(),
+			args: args{
+				obj: &unstructured.Unstructured{},
+				rel: release.Release{
+					Name:      "test",
+					Namespace: "test",
+					Chart: &chart.Chart{
+						Values: map[string]interface{}{
+							"upstream": map[string]interface{}{},
+						},
+					},
+				},
+				log: logr.Discard(),
+			},
+			wantErr: false,
+			wantVals: map[string]interface{}{
+				"upstream": map[string]interface{}{
+					"postgresql": map[string]interface{}{
+						"auth": map[string]interface{}{
+							"password":         "cGFzczEyMw==", // notsecret test secret
+							"postgresPassword": "cG9zdDEyMw==", // notsecret test secret
+						},
+					},
+				},
+			},
+		},
+		{
+			name:   "secret config not found",
+			client: fake.NewClientBuilder().WithRuntimeObjects().Build(),
+			args: args{
+				obj: &unstructured.Unstructured{},
+				rel: release.Release{
+					Name:      "test",
+					Namespace: "test",
+					Chart: &chart.Chart{
+						Values: map[string]interface{}{
+							"upstream": map[string]interface{}{},
+						},
+					},
+				},
+				log: logr.Discard(),
+			},
+			wantErr: false,
+			wantVals: map[string]interface{}{
+				"upstream": map[string]interface{}{},
+			},
+		},
+		{
+			name:   "secret config, existing chart values, upstream.postgresql.auth.password and upstream.postgresql.auth.postgresPassword already set",
+			client: fake.NewClientBuilder().WithRuntimeObjects(getSecretWithData("pass123", "post123")).Build(),
+			args: args{
+				obj: &unstructured.Unstructured{},
+				rel: release.Release{
+					Name:      "test",
+					Namespace: "test",
+					Chart: &chart.Chart{
+						Values: map[string]interface{}{
+							"upstream": map[string]interface{}{
+								"postgresql": map[string]interface{}{
+									"auth": map[string]interface{}{
+										"password":         "cGFzczEyMw==", // notsecret test secret
+										"postgresPassword": "cG9zdDEyMw==", // notsecret test secret
+									},
+								},
+							},
+						},
+					},
+				},
+				log: logr.Discard(),
+			},
+			wantErr: false,
+			wantVals: map[string]interface{}{
+				"upstream": map[string]interface{}{
+					"postgresql": map[string]interface{}{
+						"auth": map[string]interface{}{
+							"password":         "cGFzczEyMw==", // notsecret test secret
+							"postgresPassword": "cG9zdDEyMw==", // notsecret test secret
+						},
+					},
+				},
+			},
+		},
+		{
+			name:   "secret config, existing chart values, upstream.postgresql.auth.password is set and upstream.postgresql.auth.postgresPassword is not set",
+			client: fake.NewClientBuilder().WithRuntimeObjects(getSecretWithData("pass123", "post123")).Build(),
+			args: args{
+				obj: &unstructured.Unstructured{},
+				rel: release.Release{
+					Name:      "test",
+					Namespace: "test",
+					Chart: &chart.Chart{
+						Values: map[string]interface{}{
+							"upstream": map[string]interface{}{
+								"postgresql": map[string]interface{}{
+									"auth": map[string]interface{}{
+										"password": "cGFzczEyMw==", // notsecret test secret
+									},
+								},
+							},
+						},
+					},
+				},
+				log: logr.Discard(),
+			},
+			wantErr: false,
+			wantVals: map[string]interface{}{
+				"upstream": map[string]interface{}{
+					"postgresql": map[string]interface{}{
+						"auth": map[string]interface{}{
+							"password":         "cGFzczEyMw==", // notsecret test secret
+							"postgresPassword": "cG9zdDEyMw==", // notsecret test secret
+						},
+					},
+				},
+			},
+		},
+		{
+			name:   "secret config, existing chart values, upstream.postgresql.auth.password is not set and upstream.postgresql.auth.postgresPassword is set",
+			client: fake.NewClientBuilder().WithRuntimeObjects(getSecretWithData("pass123", "post123")).Build(),
+			args: args{
+				obj: &unstructured.Unstructured{},
+				rel: release.Release{
+					Name:      "test",
+					Namespace: "test",
+					Chart: &chart.Chart{
+						Values: map[string]interface{}{
+							"upstream": map[string]interface{}{
+								"postgresql": map[string]interface{}{
+									"auth": map[string]interface{}{
+										"postgresPassword": "cG9zdDEyMw==", // notsecret test secret
+									},
+								},
+							},
+						},
+					},
+				},
+				log: logr.Discard(),
+			},
+			wantErr: false,
+			wantVals: map[string]interface{}{
+				"upstream": map[string]interface{}{
+					"postgresql": map[string]interface{}{
+						"auth": map[string]interface{}{
+							"password":         "cGFzczEyMw==", // notsecret test secret
+							"postgresPassword": "cG9zdDEyMw==", // notsecret test secret
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			hook := &hooks.CheckPostPassword{
+				Client: tt.client,
+			}
+			err := hook.Exec(tt.args.obj, tt.args.rel, tt.args.log)
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("CheckPostPassword.Exec() error = %v, wantErr %v", err, tt.wantErr)
+			}
+
+			assert.EqualValues(t, tt.wantVals, tt.args.rel.Chart.Values)
+		})
+	}
+}


### PR DESCRIPTION
## Description
This PR adds a new PostHook called checkPostPassword that will check the Helm Release to see if `upstream.postgresql.auth.password` and `upstream.postgresql.auth.postgresPassword` has been set. The purpose of this is to fix the problem of reconcile error stating that `upstream.postgresql.auth.password` and  `upstream.postgresql.auth.postgresPassword` must not be empty. 

The checkPostPassword will check for the name of the postgresql secret based on whether or not `upstream.postgresql.fullnameOverride` or `upstream.postgresql.nameOverride` have been set. It will then check if the password and postgresPassword parameters have been set.

## Which issues(s) does this PR fix
- Fixes #5 
