### PR TITLE
fix rbac to add in apiGroup for ingresses.config.openshift.io

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -13,6 +13,7 @@ rules:
   - namespaces
   verbs:
   - get
+
 # We need to manage Helm release secrets
 - apiGroups:
   - ""
@@ -20,6 +21,7 @@ rules:
   - secrets
   verbs:
   - "*"
+
 # We need to create events on CRs about things happening during reconciliation
 - apiGroups:
   - ""
@@ -27,6 +29,14 @@ rules:
   - events
   verbs:
   - create
+
+# We need to get Ingress to set global.clusterRouterBase
+- apiGroups:
+  - config.openshift.io
+  resources:
+  - ingresses
+  verbs:
+  - get
 
 ##
 ## Rules for charts.janus-idp.io/v1alpha1, Kind: Backstage


### PR DESCRIPTION
## Motivation
This operator does not work properly when deployed in a cluster, this is the first step to try to get it working. As it throws the below error:

```
ERROR	controllers.Helm	pre-release hook failed	{"backstage": "openshift-operators/backstage-sample", "error": "ingresses.config.openshift.io \"cluster\" is forbidden: User
```