### PR TITLE
chore(Makefile): fixes and improvements to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -262,4 +262,11 @@ catalog-push: ## Push a catalog image.
 # Build and push all images (operator, bundle and catalog).
 # don't forget to set IMG and IMAGE_TAG_BASE vars
 .PHONY: build-push-all
-build-push-all: podman-build podman-push bundle bundle-build bundle-push catalog-build catalog-push
+build-push-all: podman-build podman-push bundle bundle-build bundle-push catalog-build catalog-push operator-hub-manifests
+
+
+# Build CatalogSource  manifest for Operator Hub
+# don't forget to set IMG IMAGE_TAG_BASE
+.PHONY: operator-hub-manifests
+operator-hub-manifests:
+	cd config/operator-hub && $(KUSTOMIZE) edit set image catalog=$(IMAGE_TAG_BASE)-catalog:v$(VERSION)

--- a/Makefile
+++ b/Makefile
@@ -58,6 +58,10 @@ else
 GOBIN=$(shell go env GOBIN)
 endif
 
+# set architecture and target OS for tools downloaded in this Makefile
+ARCH ?= amd64
+OS ?= linux
+
 # Setting SHELL to bash allows bash commands to be executed by recipes.
 # Options are set to exit when a recipe line exits non-zero or a piped command fails.
 SHELL = /usr/bin/env bash -o pipefail
@@ -176,23 +180,23 @@ $(KUSTOMIZE): $(LOCALBIN)
 .PHONY: controller-gen
 controller-gen: $(CONTROLLER_GEN) ## Download controller-gen locally if necessary.
 $(CONTROLLER_GEN): $(LOCALBIN)
-	test -s $(LOCALBIN)/controller-gen || GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-tools/cmd/controller-gen@$(CONTROLLER_TOOLS_VERSION)
+	test -s $(LOCALBIN)/controller-gen || GOBIN=$(LOCALBIN) GOOS=$(OS) GOARCH=$(ARCH) go install sigs.k8s.io/controller-tools/cmd/controller-gen@$(CONTROLLER_TOOLS_VERSION)
 
 .PHONY: envtest
 envtest: $(ENVTEST) ## Download envtest-setup locally if necessary.
 $(ENVTEST): $(LOCALBIN)
-	test -s $(LOCALBIN)/setup-envtest || GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
+	test -s $(LOCALBIN)/setup-envtest || GOBIN=$(LOCALBIN) GOOS=$(OS) GOARCH=$(ARCH) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
 
 .PHONY: bundle
-bundle: kustomize ## Generate bundle manifests and metadata, then validate generated files.
-	operator-sdk generate kustomize manifests -q
+bundle: kustomize operator-sdk ## Generate bundle manifests and metadata, then validate generated files.
+	$(OPERATOR_SDK) generate kustomize manifests -q
 	cd config/manager && $(KUSTOMIZE) edit set image controller=$(IMG)
-	$(KUSTOMIZE) build config/manifests | operator-sdk generate bundle $(BUNDLE_GEN_FLAGS)
-	operator-sdk bundle validate ./bundle
+	$(KUSTOMIZE) build config/manifests | $(OPERATOR_SDK) generate bundle $(BUNDLE_GEN_FLAGS)
+	$(OPERATOR_SDK) bundle validate ./bundle
 
 .PHONY: bundle-build
 bundle-build: ## Build the bundle image.
-	podman build -f bundle.podmanfile -t $(BUNDLE_IMG) .
+	podman build -f bundle.Dockerfile -t $(BUNDLE_IMG) .
 
 .PHONY: bundle-push
 bundle-push: ## Push the bundle image.
@@ -211,6 +215,22 @@ ifeq (,$(shell which opm 2>/dev/null))
 	}
 else
 OPM = $(shell which opm)
+endif
+endif
+
+.PHONY: operator-sdk
+OPERATOR_SDK = ./bin/operator-sdk
+operator-sdk: ## Download operator-sdk locally if necessary.
+ifeq (,$(wildcard $(OPERATOR_SDK)))
+ifeq (,$(shell which operator-sdk 2>/dev/null))
+	@{ \
+	set -e ;\
+	mkdir -p $(dir $(OPERATOR_SDK)) ;\
+	curl -sSLo $(OPERATOR_SDK) https://github.com/operator-framework/operator-sdk/releases/download/v1.32.0/operator-sdk_$(OS)_$(ARCH) ;\
+	chmod +x $(OPERATOR_SDK) ;\
+	}
+else
+OPM = $(shell which operator-sdk)
 endif
 endif
 
@@ -237,3 +257,9 @@ catalog-build: opm ## Build a catalog image.
 .PHONY: catalog-push
 catalog-push: ## Push a catalog image.
 	$(MAKE) podman-push IMG=$(CATALOG_IMG)
+
+
+# Build and push all images (operator, bundle and catalog).
+# don't forget to set IMG and IMAGE_TAG_BASE vars
+.PHONY: build-push-all
+build-push-all: podman-build podman-push bundle bundle-build bundle-push catalog-build catalog-push

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ make install
 
 ## Run
 
-Containerized:
+### Containerized
 
 ```console
 export IMG=quay.io/<foo>/<bar>:latest
@@ -24,14 +24,28 @@ make podman-push
 make deploy
 ```
 
-Or locally:
+### Inside OpenShift cluster using OperatorHub
+
+#### 1. build and push all images
+```console
+VERSION=0.0.1-dev1 IMG=quay.io/<username>/janus-operator:$VERSION IMAGE_TAG_BASE=quay.io/<username>/janus-operator make build-push-all
+```
+
+#### 2. add CatalogSource to OperatorHub
+```console
+./bin/kustomize build config/catalog/ | oc apply -f -
+```
+
+#### 3. Install RHDH-dev from OperatorHub using OpenShift Web Console
+
+### Locally
 
 ```console
 export WATCH_NAMESPACE=baz
 make run
 ```
 
-Or in VSCode:
+### in VSCode:
 
 1. Edit namespace in `.vscode/launch.json`
 2. `CTRL+SHIFT+D`, run **Launch Backstage Operator**

--- a/config/operator-hub/CatalogSource.yaml
+++ b/config/operator-hub/CatalogSource.yaml
@@ -1,0 +1,10 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: CatalogSource
+metadata:
+  name: rhdh-dev
+  namespace: openshift-operators
+spec:
+  sourceType: grpc
+  image: catalog
+  publisher: RHDH Developer
+  displayName: RHDH dev

--- a/config/operator-hub/kustomization.yaml
+++ b/config/operator-hub/kustomization.yaml
@@ -1,0 +1,17 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: openshift-operators
+
+
+
+resources:
+- CatalogSource.yaml
+
+configurations:
+- kustomizeconfig/CatalogSource.yaml
+
+images:
+- name: catalog
+  newName: catalog
+  newTag: latest

--- a/config/operator-hub/kustomizeconfig/CatalogSource.yaml
+++ b/config/operator-hub/kustomizeconfig/CatalogSource.yaml
@@ -1,0 +1,6 @@
+
+
+# custom kustomize transformer to support image patching
+images:
+- path: spec/image
+  kind: CatalogSource


### PR DESCRIPTION
 - fixes `bundle-build` target
 - adds `operator-sdk` target for downloading operator-sdk
 - adds `build-push-all` target to build and push all operator related images
 - adds `operator-hub-manifests` to generate `CatalogSource` for testing
