### PR TITLE
fix(rbac): add missing RBAC role for Routes

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -89,5 +89,17 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - route.openshift.io
+  resources:
+  - routes
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
 
 #+kubebuilder:scaffold:rules


### PR DESCRIPTION
the operator needs permissions for OpenShift Route in order to be able to manage Routes created by Helm chart