### PR TITLE
add checkPostPassword PreHook

### DIFF
--- a/main.go
+++ b/main.go
@@ -131,6 +131,12 @@ func main() {
 			Client: cl,
 		}
 
+		randomString := &hooks.DefaultRandomStringGenerator{}
+		checkPostPassword := &hooks.CheckPostPassword{
+			Client:    cl,
+			Generator: randomString,
+		}
+
 		r, err := reconciler.New(
 			reconciler.WithChart(*w.Chart),
 			reconciler.WithGroupVersionKind(w.GroupVersionKind),
@@ -142,6 +148,7 @@ func main() {
 			reconciler.WithUpgradeAnnotations(annotation.DefaultUpgradeAnnotations...),
 			reconciler.WithUninstallAnnotations(annotation.DefaultUninstallAnnotations...),
 			reconciler.WithPreHook(setClusterRouterBaseHook),
+			reconciler.WithPreHook(checkPostPassword),
 		)
 
 		if err != nil {

--- a/pkg/hooks/secret-prehook.go
+++ b/pkg/hooks/secret-prehook.go
@@ -1,0 +1,90 @@
+package hooks
+
+import (
+	"math/rand"
+	"time"
+
+	"github.com/go-logr/logr"
+	"helm.sh/helm/v3/pkg/chartutil"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type RandomStringGenerator interface {
+	GenerateRandomString() (string, error)
+}
+
+type DefaultRandomStringGenerator struct{}
+
+type CheckPostPassword struct {
+	Client    client.Client
+	Generator RandomStringGenerator
+}
+
+// PreHook function to determine if upstream.postgresql.auth.password and upstream.postgresql.auth.postgresPassword has been set.
+// Sets those parameters to the secret that has been created after the chart has been installed
+func (h *CheckPostPassword) Exec(obj *unstructured.Unstructured, vals chartutil.Values, log logr.Logger) error {
+
+	if h.shouldSkipSettingPassword(vals) {
+		log.V(1).Info("PreHook: skipping setting upstream.posgresql.auth.password and upstream.postgresql.auth.postgresPassword")
+		return nil
+	}
+
+	pass, err := h.Generator.GenerateRandomString()
+	if err != nil {
+		return err
+	}
+	postPass, err := h.Generator.GenerateRandomString()
+	if err != nil {
+		return err
+	}
+
+	h.setAuthPasswords(vals, pass, postPass)
+
+	log.V(1).Info("PreHook: setting upstream.postgresql.auth.password and upstream.postgresql.auth.postgresPassword")
+
+	return nil
+}
+
+func (g *DefaultRandomStringGenerator) GenerateRandomString() (string, error) {
+	var seededRand *rand.Rand = rand.New(rand.NewSource(time.Now().UnixNano()))
+	charSet := "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+	var SecretLength = 16
+	token := make([]byte, SecretLength)
+
+	for i := range token {
+		token[i] = charSet[seededRand.Intn(len(charSet))]
+	}
+
+	return string(token), nil
+}
+
+func (h *CheckPostPassword) shouldSkipSettingPassword(vals chartutil.Values) bool {
+
+	_, passFound, _ := unstructured.NestedString(vals, "upstream", "postgresql", "auth", "password")
+	_, postFound, _ := unstructured.NestedString(vals, "upstream", "postgresql", "auth", "postgresPassword")
+
+	return passFound && postFound
+}
+
+func (h *CheckPostPassword) setAuthPasswords(vals chartutil.Values, pass interface{}, postPass interface{}) {
+	ensureNestedMap(vals, "upstream", "postgresql", "auth")
+	ensureNestedMap(vals, "backstage", "postgresql", "auth")
+
+	vals["upstream"].(map[string]interface{})["postgresql"].(map[string]interface{})["auth"].(map[string]interface{})["password"] = pass
+	vals["upstream"].(map[string]interface{})["postgresql"].(map[string]interface{})["auth"].(map[string]interface{})["postgresPassword"] = postPass
+
+	vals["backstage"].(map[string]interface{})["postgresql"].(map[string]interface{})["auth"].(map[string]interface{})["password"] = pass
+	vals["backstage"].(map[string]interface{})["postgresql"].(map[string]interface{})["auth"].(map[string]interface{})["postgresPassword"] = postPass
+}
+
+// Helper function to ensure that the nested map, upstream.posgresql.auth, is there
+func ensureNestedMap(m map[string]interface{}, keys ...string) {
+	for _, key := range keys {
+		_, ok := m[key].(map[string]interface{})
+		if !ok {
+			m[key] = map[string]interface{}{}
+		}
+		m = m[key].(map[string]interface{})
+	}
+}

--- a/pkg/hooks/secret-prehook_test.go
+++ b/pkg/hooks/secret-prehook_test.go
@@ -1,0 +1,161 @@
+package hooks_test
+
+import (
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/janus-idp/backstage-operator/pkg/hooks"
+	"github.com/stretchr/testify/assert"
+	"helm.sh/helm/v3/pkg/chartutil"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+// Test cases that need to be covered
+// - Not set
+// - - It will set the fields
+// - Is set
+// - - It will skip setting the fields
+
+type MockRandomStringGenerator struct{}
+
+func (g *MockRandomStringGenerator) GenerateRandomString() (string, error) {
+	return "test", nil
+}
+
+func TestCheckPostPassword(t *testing.T) {
+	type args struct {
+		obj  *unstructured.Unstructured
+		vals chartutil.Values
+		log  logr.Logger
+	}
+
+	tests := []struct {
+		name     string
+		client   client.Client
+		args     args
+		wantErr  bool
+		wantVals chartutil.Values
+	}{
+		{
+			name:   "password and postgresPassword not set, empty chart values",
+			client: fake.NewClientBuilder().Build(),
+			args: args{
+				obj:  &unstructured.Unstructured{},
+				vals: chartutil.Values{},
+				log:  logr.Discard(),
+			},
+			wantErr: false,
+			wantVals: chartutil.Values{
+				"backstage": map[string]interface{}{
+					"postgresql": map[string]interface{}{
+						"auth": map[string]interface{}{
+							"password":         "test",
+							"postgresPassword": "test",
+						},
+					},
+				},
+				"upstream": map[string]interface{}{
+					"postgresql": map[string]interface{}{
+						"auth": map[string]interface{}{
+							"password":         "test",
+							"postgresPassword": "test",
+						},
+					},
+				},
+			},
+		},
+		{
+			name:   "password and postgresPassword not set, existing chart values, but no auth section",
+			client: fake.NewClientBuilder().Build(),
+			args: args{
+				obj:  &unstructured.Unstructured{},
+				vals: chartutil.Values{"foo": "baz"},
+				log:  logr.Discard(),
+			},
+			wantErr: false,
+			wantVals: chartutil.Values{
+				"backstage": map[string]interface{}{
+					"postgresql": map[string]interface{}{
+						"auth": map[string]interface{}{
+							"password":         "test",
+							"postgresPassword": "test",
+						},
+					},
+				},
+				"foo": "baz",
+				"upstream": map[string]interface{}{
+					"postgresql": map[string]interface{}{
+						"auth": map[string]interface{}{
+							"password":         "test",
+							"postgresPassword": "test",
+						},
+					},
+				},
+			},
+		},
+		{
+			name:   "password and postgresPassword are set",
+			client: fake.NewClientBuilder().Build(),
+			args: args{
+				obj: &unstructured.Unstructured{},
+				vals: chartutil.Values{
+					"backstage": map[string]interface{}{
+						"postgresql": map[string]interface{}{
+							"auth": map[string]interface{}{
+								"password":         "test2",
+								"postgresPassword": "test2",
+							},
+						},
+					},
+					"upstream": map[string]interface{}{
+						"postgresql": map[string]interface{}{
+							"auth": map[string]interface{}{
+								"password":         "test2",
+								"postgresPassword": "test2",
+							},
+						},
+					},
+				},
+				log: logr.Discard(),
+			},
+			wantErr: false,
+			wantVals: chartutil.Values{
+				"backstage": map[string]interface{}{
+					"postgresql": map[string]interface{}{
+						"auth": map[string]interface{}{
+							"password":         "test2",
+							"postgresPassword": "test2",
+						},
+					},
+				},
+				"upstream": map[string]interface{}{
+					"postgresql": map[string]interface{}{
+						"auth": map[string]interface{}{
+							"password":         "test2",
+							"postgresPassword": "test2",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockGenerator := &MockRandomStringGenerator{}
+			hook := &hooks.CheckPostPassword{
+				Client:    tt.client,
+				Generator: mockGenerator,
+			}
+			err := hook.Exec(tt.args.obj, tt.args.vals, tt.args.log)
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("CheckPostPassword.Exec() error = %v, wantErr %v", err, tt.wantErr)
+			}
+
+			assert.EqualValues(t, tt.wantVals, tt.args.vals)
+		})
+	}
+}


### PR DESCRIPTION
## Description
This PR adds a new PreHook called checkPostPassword that will check the Helm Release to see if `upstream.postgresql.auth.password` and `upstream.postgresql.auth.postgresPassword` has been set. The purpose of this is to fix the problem of reconcile error stating that `upstream.postgresql.auth.password` and  `upstream.postgresql.auth.postgresPassword` must not be empty. 

The checkPostPassword will randomly generate a string for the password and postgresPassword fields whenever the helm chart is installed. These will then be picked up by the PostgreSQL helm chart. If these fields already have input in them, this prehook will skip adding to the fields.

Currently, there is a limitation to this that we will need to document. Essentially, if a user decides to enter in an existingSecret, they will also need to enter in the password and postgresPassword for the operator to work. The reason is that the operator will perform a dry run periodically and before any upgrades. This will lead to the error that the password and postgresPassword must not be empty.

One other thing to note. I had to update both the upstream and backstage values whenever I am setting the password. For some reason there is an issue with using one or the other. Only setting upstream will lead to the password error and only setting backstage will make it so that I can not skip setting the fields. 

## Which issues(s) does this PR fix
- Fixes #5 