### PR TITLE
chore(renovate): enable git submodule updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,5 +2,8 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:base"
-  ]
+  ],
+  "git-submodules": {
+    "enabled": true
+  }
 }


### PR DESCRIPTION
According to docs, we need to explicitly enable Git submodule updates in renovate:

https://docs.renovatebot.com/modules/manager/git-submodules/